### PR TITLE
Allow arbitrary environment names

### DIFF
--- a/lib/raad/env.rb
+++ b/lib/raad/env.rb
@@ -13,13 +13,14 @@ module Raad
 
   # sets the current environment
   #
-  # @param [String or Symbol] env the environment [development|production|stage|test]
+  # @param [String or Symbol] env the environment
   def env=(env)
     case(env.to_s)
     when 'dev', 'development' then @env = :development
     when 'prod', 'production' then @env = :production
     when 'stage', 'staging' then @env = :stage
     when 'test' then @env = :test
+    else @env = env.to_sym
     end
   end
 


### PR DESCRIPTION
I modified the `Raad.env=` method so it can accept non-standard environment values (such as `"preproduction"` instead of `"stage"`).

Tell me what you think!
